### PR TITLE
[JENKINS-35329] Remove unused BC dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ lib/
 
 */crx-quickstart/
 work/
+
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -159,18 +159,6 @@
             <version>0.3</version>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.49</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.49</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20080701</version>


### PR DESCRIPTION
[JENKINS-35329](https://issues.jenkins-ci.org/browse/JENKINS-35329)

Also updated `.gitignore` to ignore eclipse related files.

@reviewbybees 
