### PR TITLE
[FIX JENKINS-31463] Implement Serializable.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/graniteclient/JenkinsResponseProgressListener.java
+++ b/src/main/java/org/jenkinsci/plugins/graniteclient/JenkinsResponseProgressListener.java
@@ -30,10 +30,12 @@ package org.jenkinsci.plugins.graniteclient;
 import hudson.model.TaskListener;
 import net.adamcin.granite.client.packman.ResponseProgressListener;
 
+import java.io.Serializable;
+
 /**
  * Wraps a {@link TaskListener} in a {@link ResponseProgressListener} interface
  */
-public class JenkinsResponseProgressListener implements ResponseProgressListener {
+public class JenkinsResponseProgressListener implements ResponseProgressListener, Serializable {
 
     final TaskListener listener;
 


### PR DESCRIPTION
Building on a slave machine you receive the following error:

```
Caused by: java.io.NotSerializableException: org.jenkinsci.plugins.graniteclient.JenkinsResponseProgressListener
at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1183)
at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1547)
at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1508)
at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1547)
at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1508)
at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
at hudson.remoting.UserRequest._serialize(UserRequest.java:158)
at hudson.remoting.UserRequest.serialize(UserRequest.java:167)
```

So the JenkinsResponseProgressListener is not Serializable.

@reviewbybees 
