### PR TITLE
[JEP-200] Whitelist PackId for use from IdentifyPackageCallable

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,1 @@
+net.adamcin.granite.client.packman.PackId


### PR DESCRIPTION
Provides _possible_ compatibility with https://github.com/jenkinsci/jenkins/pull/3120. This plugin seems to have no real functional tests, much less anything using `JenkinsRule.createSlave`, and I scarcely even know what it is supposed to do so I did not try to run it manually.

Better might be to make the callable return a plain `String`, then call `PackId.parsePid`. I am not sure `PackId.toString` is the exact opposite, though.

@reviewbybees